### PR TITLE
Documentation only - fix the wrong name in the document of bme280

### DIFF
--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -1,7 +1,7 @@
 # BME280 module
 | Since  | Origin / Contributor  | Maintainer  | Source  |
 | :----- | :-------------------- | :---------- | :------ |
-| 2016-02-21 | [vsky279](https://github.com/vsky279) | [vsky279](https://github.com/vsky279) | [bit.c](../../../app/modules/bme280.c)|
+| 2016-02-21 | [vsky279](https://github.com/vsky279) | [vsky279](https://github.com/vsky279) | [bme280.c](../../../app/modules/bme280.c)|
 
 This module provides a simple interface to [BME280/BMP280 temperature/air presssure/humidity sensors](http://www.bosch-sensortec.com/bst/products/all_products/bme280) (Bosch Sensortec).
 


### PR DESCRIPTION
Fixes #1 .

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.
- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

<Description of and rational behind this PR>

Committers supporting this PR: leave blank

The name should be bme280.c, not bit.c .
